### PR TITLE
[FIX] Updated SkiaSharp to stop app from crashing

### DIFF
--- a/source/EduCATS.Android/EduCATS.Android.csproj
+++ b/source/EduCATS.Android/EduCATS.Android.csproj
@@ -72,6 +72,9 @@
     <PackageReference Include="CarouselView.FormsPlugin">
       <Version>6.0.0</Version>
     </PackageReference>
+    <PackageReference Include="SkiaSharp">
+      <Version>2.88.8</Version>
+    </PackageReference>
     <PackageReference Include="Xamarin.Forms" Version="5.0.0.2612" />
     <PackageReference Include="Xamarin.Essentials" Version="1.8.0" />
     <PackageReference Include="MonkeyCache.FileStore">

--- a/source/EduCATS.Android/packages.lock.json
+++ b/source/EduCATS.Android/packages.lock.json
@@ -66,6 +66,15 @@
           "Newtonsoft.Json": "12.0.3"
         }
       },
+      "SkiaSharp": {
+        "type": "Direct",
+        "requested": "[2.88.8, )",
+        "resolved": "2.88.8",
+        "contentHash": "bRkp3uKp5ZI8gXYQT57uKwil1uobb2p8c69n7v5evlB/2JNcMAXVcw9DZAP5Ig3WSvgzGm2YSn27UVeOi05NlA==",
+        "dependencies": {
+          "SkiaSharp.NativeAssets.Android": "2.88.8"
+        }
+      },
       "Xamarin.Essentials": {
         "type": "Direct",
         "requested": "[1.8.0, )",
@@ -185,18 +194,10 @@
         "resolved": "13.0.1",
         "contentHash": "ppPFpBcvxdsfUonNcvITKqLl3bqxWbDCZIzDWHzjpdAHRFfZe0Dw9HmA0+za13IdyrgJwpkDTDA9fHaxOrt20A=="
       },
-      "SkiaSharp": {
-        "type": "Transitive",
-        "resolved": "2.88.6",
-        "contentHash": "wdfeBAQrEQCbJIRgAiargzP1Uy+0grZiG4CSgBnhAgcJTsPzlifIaO73JRdwIlT3TyBoeU9jEqzwFUhl4hTYnQ==",
-        "dependencies": {
-          "SkiaSharp.NativeAssets.Android": "2.88.6"
-        }
-      },
       "SkiaSharp.NativeAssets.Android": {
         "type": "Transitive",
-        "resolved": "2.88.6",
-        "contentHash": "yFtWleVp7hRhSPuyEJPlTRsiEQANTHJuREcpIFiFG9bdGmYgAS5CMJXOiO67jyUT7v7vSj3Qk34I7P5FRm1wUg=="
+        "resolved": "2.88.8",
+        "contentHash": "tq417LpTlN9BB02LDnODI5WpTiaf2Wqwp9VsrUpLv1XOAXsIMscQrCagJbYkpfheZ0YoiqG4QuTMcQXL+P+4kg=="
       },
       "SkiaSharp.Views": {
         "type": "Transitive",
@@ -1010,7 +1011,7 @@
           "Microcharts.Forms": "[0.9.5.9, )",
           "MonkeyCache.FileStore": "[1.6.3, )",
           "Nyxbull.Plugins.CrossLocalization": "[1.3.1, )",
-          "SkiaSharp": "[2.88.6, )",
+          "SkiaSharp": "[2.88.8, )",
           "System.IdentityModel.Tokens.Jwt": "[7.6.0, )",
           "Xamarin.Essentials": "[1.8.0, )",
           "Xamarin.FFImageLoading": "[2.4.11.982, )",

--- a/source/EduCATS.UnitTests/packages.lock.json
+++ b/source/EduCATS.UnitTests/packages.lock.json
@@ -183,22 +183,22 @@
       },
       "SkiaSharp": {
         "type": "Transitive",
-        "resolved": "2.88.6",
-        "contentHash": "wdfeBAQrEQCbJIRgAiargzP1Uy+0grZiG4CSgBnhAgcJTsPzlifIaO73JRdwIlT3TyBoeU9jEqzwFUhl4hTYnQ==",
+        "resolved": "2.88.8",
+        "contentHash": "bRkp3uKp5ZI8gXYQT57uKwil1uobb2p8c69n7v5evlB/2JNcMAXVcw9DZAP5Ig3WSvgzGm2YSn27UVeOi05NlA==",
         "dependencies": {
-          "SkiaSharp.NativeAssets.Win32": "2.88.6",
-          "SkiaSharp.NativeAssets.macOS": "2.88.6"
+          "SkiaSharp.NativeAssets.Win32": "2.88.8",
+          "SkiaSharp.NativeAssets.macOS": "2.88.8"
         }
       },
       "SkiaSharp.NativeAssets.macOS": {
         "type": "Transitive",
-        "resolved": "2.88.6",
-        "contentHash": "Sko9LFxRXSjb3OGh5/RxrVRXxYo48tr5NKuuSy6jB85GrYt8WRqVY1iLOLwtjPiVAt4cp+pyD4i30azanS64dw=="
+        "resolved": "2.88.8",
+        "contentHash": "6Kn5TSkKlfyS6azWHF3Jk2sW5C4jCE5uSshM/5AbfFrR+5n6qM5XEnz9h4VaVl7LTxBvHvMkuPb/3bpbq0vxTw=="
       },
       "SkiaSharp.NativeAssets.Win32": {
         "type": "Transitive",
-        "resolved": "2.88.6",
-        "contentHash": "7TzFO0u/g2MpQsTty4fyCDdMcfcWI+aLswwfnYXr3gtNS6VLKdMXPMeKpJa3pJSLnUBN6wD0JjuCe8OoLBQ6cQ=="
+        "resolved": "2.88.8",
+        "contentHash": "O9QXoWEXA+6cweR4h3BOnwMz+pO9vL9mXdjLrpDd0w1QzCgWmLQBxa1VgySDITiH7nQndrDG1h6937zm9pLj1Q=="
       },
       "SkiaSharp.Views.Forms": {
         "type": "Transitive",
@@ -282,7 +282,7 @@
           "Microcharts.Forms": "[0.9.5.9, )",
           "MonkeyCache.FileStore": "[1.6.3, )",
           "Nyxbull.Plugins.CrossLocalization": "[1.3.1, )",
-          "SkiaSharp": "[2.88.6, )",
+          "SkiaSharp": "[2.88.8, )",
           "System.IdentityModel.Tokens.Jwt": "[7.6.0, )",
           "Xamarin.Essentials": "[1.8.0, )",
           "Xamarin.FFImageLoading": "[2.4.11.982, )",

--- a/source/EduCATS.iOS/EduCATS.iOS.csproj
+++ b/source/EduCATS.iOS/EduCATS.iOS.csproj
@@ -665,6 +665,9 @@
     <PackageReference Include="CarouselView.FormsPlugin">
       <Version>6.0.0</Version>
     </PackageReference>
+    <PackageReference Include="SkiaSharp">
+      <Version>2.88.8</Version>
+    </PackageReference>
     <PackageReference Include="Xamarin.Forms" Version="5.0.0.2612" />
     <PackageReference Include="Xamarin.Essentials" Version="1.8.0" />
     <PackageReference Include="MonkeyCache.FileStore">

--- a/source/EduCATS.iOS/packages.lock.json
+++ b/source/EduCATS.iOS/packages.lock.json
@@ -62,6 +62,15 @@
           "Newtonsoft.Json": "12.0.3"
         }
       },
+      "SkiaSharp": {
+        "type": "Direct",
+        "requested": "[2.88.8, )",
+        "resolved": "2.88.8",
+        "contentHash": "bRkp3uKp5ZI8gXYQT57uKwil1uobb2p8c69n7v5evlB/2JNcMAXVcw9DZAP5Ig3WSvgzGm2YSn27UVeOi05NlA==",
+        "dependencies": {
+          "SkiaSharp.NativeAssets.iOS": "2.88.8"
+        }
+      },
       "Xamarin.Essentials": {
         "type": "Direct",
         "requested": "[1.8.0, )",
@@ -171,18 +180,10 @@
         "resolved": "13.0.1",
         "contentHash": "ppPFpBcvxdsfUonNcvITKqLl3bqxWbDCZIzDWHzjpdAHRFfZe0Dw9HmA0+za13IdyrgJwpkDTDA9fHaxOrt20A=="
       },
-      "SkiaSharp": {
-        "type": "Transitive",
-        "resolved": "2.88.6",
-        "contentHash": "wdfeBAQrEQCbJIRgAiargzP1Uy+0grZiG4CSgBnhAgcJTsPzlifIaO73JRdwIlT3TyBoeU9jEqzwFUhl4hTYnQ==",
-        "dependencies": {
-          "SkiaSharp.NativeAssets.iOS": "2.88.6"
-        }
-      },
       "SkiaSharp.NativeAssets.iOS": {
         "type": "Transitive",
-        "resolved": "2.88.6",
-        "contentHash": "j+Nv2cKDb6YZDebtIWjaypG7rngEw7xLvB0WlCoIpUShop0jPLutoqiPx2r4FFt72egzVhUrUn/rlyL7EeYpTA=="
+        "resolved": "2.88.8",
+        "contentHash": "bo00z/N46eptBnCrdrLNMwLpJnjjMHJDW8c3/gA6WsGEc4M+n02WpQUbCukZMZzAGq4XmLMzBg46LcElHlAU6Q=="
       },
       "SkiaSharp.Views": {
         "type": "Transitive",
@@ -271,7 +272,7 @@
           "Microcharts.Forms": "[0.9.5.9, )",
           "MonkeyCache.FileStore": "[1.6.3, )",
           "Nyxbull.Plugins.CrossLocalization": "[1.3.1, )",
-          "SkiaSharp": "[2.88.6, )",
+          "SkiaSharp": "[2.88.8, )",
           "System.IdentityModel.Tokens.Jwt": "[7.6.0, )",
           "Xamarin.Essentials": "[1.8.0, )",
           "Xamarin.FFImageLoading": "[2.4.11.982, )",
@@ -284,8 +285,20 @@
     "Xamarin.iOS,Version=v1.0/win": {
       "SkiaSharp.NativeAssets.iOS": {
         "type": "Transitive",
-        "resolved": "2.88.6",
-        "contentHash": "j+Nv2cKDb6YZDebtIWjaypG7rngEw7xLvB0WlCoIpUShop0jPLutoqiPx2r4FFt72egzVhUrUn/rlyL7EeYpTA=="
+        "resolved": "2.88.8",
+        "contentHash": "bo00z/N46eptBnCrdrLNMwLpJnjjMHJDW8c3/gA6WsGEc4M+n02WpQUbCukZMZzAGq4XmLMzBg46LcElHlAU6Q=="
+      },
+      "System.Security.Cryptography.Cng": {
+        "type": "Transitive",
+        "resolved": "4.5.0",
+        "contentHash": "WG3r7EyjUe9CMPFSs6bty5doUqT+q9pbI80hlNzo2SkPkZ4VTuZkGWjpp77JB8+uaL4DFPRdBsAY+DX3dBK92A=="
+      }
+    },
+    "Xamarin.iOS,Version=v1.0/win-arm64": {
+      "SkiaSharp.NativeAssets.iOS": {
+        "type": "Transitive",
+        "resolved": "2.88.8",
+        "contentHash": "bo00z/N46eptBnCrdrLNMwLpJnjjMHJDW8c3/gA6WsGEc4M+n02WpQUbCukZMZzAGq4XmLMzBg46LcElHlAU6Q=="
       },
       "System.Security.Cryptography.Cng": {
         "type": "Transitive",
@@ -296,8 +309,8 @@
     "Xamarin.iOS,Version=v1.0/win-x64": {
       "SkiaSharp.NativeAssets.iOS": {
         "type": "Transitive",
-        "resolved": "2.88.6",
-        "contentHash": "j+Nv2cKDb6YZDebtIWjaypG7rngEw7xLvB0WlCoIpUShop0jPLutoqiPx2r4FFt72egzVhUrUn/rlyL7EeYpTA=="
+        "resolved": "2.88.8",
+        "contentHash": "bo00z/N46eptBnCrdrLNMwLpJnjjMHJDW8c3/gA6WsGEc4M+n02WpQUbCukZMZzAGq4XmLMzBg46LcElHlAU6Q=="
       },
       "System.Security.Cryptography.Cng": {
         "type": "Transitive",
@@ -308,8 +321,8 @@
     "Xamarin.iOS,Version=v1.0/win-x86": {
       "SkiaSharp.NativeAssets.iOS": {
         "type": "Transitive",
-        "resolved": "2.88.6",
-        "contentHash": "j+Nv2cKDb6YZDebtIWjaypG7rngEw7xLvB0WlCoIpUShop0jPLutoqiPx2r4FFt72egzVhUrUn/rlyL7EeYpTA=="
+        "resolved": "2.88.8",
+        "contentHash": "bo00z/N46eptBnCrdrLNMwLpJnjjMHJDW8c3/gA6WsGEc4M+n02WpQUbCukZMZzAGq4XmLMzBg46LcElHlAU6Q=="
       },
       "System.Security.Cryptography.Cng": {
         "type": "Transitive",

--- a/source/EduCATS/EduCATS.csproj
+++ b/source/EduCATS/EduCATS.csproj
@@ -21,7 +21,7 @@
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="CarouselView.FormsPlugin" Version="6.0.0" />
-        <PackageReference Include="SkiaSharp" Version="2.88.6" />
+        <PackageReference Include="SkiaSharp" Version="2.88.8" />
         <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.6.0" />
         <PackageReference Include="Xamarin.Forms" Version="5.0.0.2612" />
         <PackageReference Include="Xamarin.Essentials" Version="1.8.0" />

--- a/source/EduCATS/packages.lock.json
+++ b/source/EduCATS/packages.lock.json
@@ -67,12 +67,12 @@
       },
       "SkiaSharp": {
         "type": "Direct",
-        "requested": "[2.88.6, )",
-        "resolved": "2.88.6",
-        "contentHash": "wdfeBAQrEQCbJIRgAiargzP1Uy+0grZiG4CSgBnhAgcJTsPzlifIaO73JRdwIlT3TyBoeU9jEqzwFUhl4hTYnQ==",
+        "requested": "[2.88.8, )",
+        "resolved": "2.88.8",
+        "contentHash": "bRkp3uKp5ZI8gXYQT57uKwil1uobb2p8c69n7v5evlB/2JNcMAXVcw9DZAP5Ig3WSvgzGm2YSn27UVeOi05NlA==",
         "dependencies": {
-          "SkiaSharp.NativeAssets.Win32": "2.88.6",
-          "SkiaSharp.NativeAssets.macOS": "2.88.6",
+          "SkiaSharp.NativeAssets.Win32": "2.88.8",
+          "SkiaSharp.NativeAssets.macOS": "2.88.8",
           "System.Memory": "4.5.5"
         }
       },
@@ -194,13 +194,13 @@
       },
       "SkiaSharp.NativeAssets.macOS": {
         "type": "Transitive",
-        "resolved": "2.88.6",
-        "contentHash": "Sko9LFxRXSjb3OGh5/RxrVRXxYo48tr5NKuuSy6jB85GrYt8WRqVY1iLOLwtjPiVAt4cp+pyD4i30azanS64dw=="
+        "resolved": "2.88.8",
+        "contentHash": "6Kn5TSkKlfyS6azWHF3Jk2sW5C4jCE5uSshM/5AbfFrR+5n6qM5XEnz9h4VaVl7LTxBvHvMkuPb/3bpbq0vxTw=="
       },
       "SkiaSharp.NativeAssets.Win32": {
         "type": "Transitive",
-        "resolved": "2.88.6",
-        "contentHash": "7TzFO0u/g2MpQsTty4fyCDdMcfcWI+aLswwfnYXr3gtNS6VLKdMXPMeKpJa3pJSLnUBN6wD0JjuCe8OoLBQ6cQ=="
+        "resolved": "2.88.8",
+        "contentHash": "O9QXoWEXA+6cweR4h3BOnwMz+pO9vL9mXdjLrpDd0w1QzCgWmLQBxa1VgySDITiH7nQndrDG1h6937zm9pLj1Q=="
       },
       "SkiaSharp.Views.Forms": {
         "type": "Transitive",


### PR DESCRIPTION
### Description of change

<!-- Please provide summary of the changes -->
Summary: Changed SkiaSharp from 2.88.6 to 2.88.8 to stop the on-load app crash

### Platforms affected

<!-- Remove unnecessary items -->
- All platforms (iOS, Android)

### Kind of changes

<!-- Remove unnecessary items -->
- Behavioral (Logic)

### Checks

- [x] Targets the correct branch
- [x] Fully localized
- [x] Documentation for added code
- [x] Unit tests for added code
- [x] Works on Android
- [x] Works on iOS
