### PR TITLE
[UPDATE] Removed shadows from "About"

### DIFF
--- a/source/EduCATS/Pages/Settings/Profile/Views/ProfilePageView.cs
+++ b/source/EduCATS/Pages/Settings/Profile/Views/ProfilePageView.cs
@@ -60,6 +60,7 @@ namespace EduCATS.Pages.Settings.Profile.Views
 			{
 				CornerRadius = 10,
 				Padding = 0,
+				HasShadow = false,
 				BackgroundColor = Color.FromHex(Theme.Current.SettingsTableColor),
 				Content = new StackLayout
 				{
@@ -102,6 +103,7 @@ namespace EduCATS.Pages.Settings.Profile.Views
 			{
 				CornerRadius = 10,
 				Padding = 0,
+				HasShadow = false,
 				BackgroundColor = Color.FromHex(Theme.Current.SettingsTableColor),
 				Content = new StackLayout
 				{
@@ -174,6 +176,7 @@ namespace EduCATS.Pages.Settings.Profile.Views
 			{
 				CornerRadius = 10,
 				Padding = 0,
+				HasShadow = false,
 				BackgroundColor = Color.FromHex(Theme.Current.SettingsTableColor),
 				Content = layout
 			};


### PR DESCRIPTION
### Description of change
Summary: 
Removed shadows on all devices from About page

### Platforms affected
- All platforms (iOS, Android)

### Kind of changes
- Visual (UI)

### Screenshots

<details>
 <summary>Open screenshots</summary>
 
<img width="514" alt="Снимок экрана 2024-10-14 в 23 10 59" src="https://github.com/user-attachments/assets/aa8ca2ee-8a8e-4429-849b-a1e8eef5d216">

 
</details>

### Checks

- [x] Targets the correct branch
- [x] Fully localized
- [x] Documentation for added code
- [x] Unit tests for added code
- [x] Works on Android
- [x] Works on iOS
